### PR TITLE
Add acceptance test installation instructions.

### DIFF
--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -25,7 +25,7 @@ For more information about Crunchy PostgreSQL, see the [Crunchy Data](http://cru
 <dd><strong>Version</strong>: v1.05 </dd>
 <dd><strong>Release date</strong>: December 22, 2016</dd>
 <dd><strong>Software component version</strong>: PostgreSQL 9.5</dd>
-<dd><strong>Compatible Ops Manager version(s)</strong>: v1.6x, v1.7.x, v1.8.x</dd>
+<dd><strong>Compatible Ops Manager version(s)</strong>: v1.6.x, v1.7.x, v1.8.x</dd>
 <dd><strong>Compatible Elastic Runtime version(s)</strong>: v1.6.x, v1.7.x, v1.8.x</dd>
 <dd><strong>vSphere support?</strong> Yes</dd>
 <dd><strong>OpenStack support?</strong> Yes</dd>

--- a/docs-content/installing.html.md.erb
+++ b/docs-content/installing.html.md.erb
@@ -140,6 +140,20 @@ Disable this checkbox if your Cloud Foundry deployment uses self-signed certific
 
 1. Click **Save**.
 
+###<a id='install-acceptance-tests'></a> Acceptance Tests Configuration
+
+The Crunchy PostgreSQL tile deploys a test application to Cloud Foundry to verify installation was successful.  This section gathers information required to d
+
+1. Click **Acceptance Tests Configuration**.
+
+1. Enter an Org name that already exists in Cloud Foundry.  See Apps Manager in Cloud Foundry to find an Org that already exists.
+
+1. Enter a Space name that already exists in Cloud Foundry.  See Apps Manager in Cloud Foundry to find a Space that already exists.
+
+1. Enter a Domain name that already exists in Cloud Foundry.  See Apps Manager in Cloud Foundry to find a Domain that already exists.
+
+1. Click **Save**.
+
 ###<a id='install-resources-conf'></a> Resource Configuration
 
 You can configure Crunchy PostgreSQL and its services to meet any application demand.  


### PR DESCRIPTION
Small patch to the documentation that adds instructions for a minor fix in the new version of our tile, `1.0.5-1`.