### PR TITLE
Fix disaster instructions, remove failover limitation

### DIFF
--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -13,7 +13,7 @@ Crunchy PostgreSQL For PCF includes the following key features:
 
 * On-Demand single-tenant service
 * Crunchy PostgreSQL v9.5 and PostGIS v2.3
-* Leader/follower PostgreSQL architecture
+* Primary/replica PostgreSQL architecture
 * Load-balanced read replicas
 * Automated backups with pgBackrest
 * Disaster recovery 
@@ -65,7 +65,6 @@ Crunchy PostgreSQL for PCF:
 Crunchy PostgreSQL for PCF currently includes the following limitations:
 
 * You must manually restore backups.
-* You must manually perform failovers.
 
 ## <a id="feedback"></a>Feedback
 

--- a/docs-content/using.html.md.erb
+++ b/docs-content/using.html.md.erb
@@ -60,8 +60,8 @@ You can check the status of your service from the space dashboard in the Service
     <pre class="terminal">
     cf create-service postgresql-9.5-odb small myService -c '
     {
-        "db_name": "crunchydb",
-        "db_username": "crunchy",
+        "db_name": "testdb",
+        "db_username": "testrole",
         "owner_name": "Crunchy Data",
         "owner_email": "admin@crunchydata.com"
     }'
@@ -94,12 +94,24 @@ Currently, individual databases cannot be restored. All databases are restored i
 
 These instructions demonstrate how the database can be restored using only deltas between the backup and the database.
 
-The following requires an administrator to SSH to the `postgresql-master` server. 
-For guidance on SSHing to servers in the service, see the [Advanced Troubleshooting with the BOSH CLI](https://docs.pivotal.io/pivotalcf/1-8/customizing/trouble-advanced.html).
+The following requires an administrator to SSH to the primary `postgresql` server. 
+For guidance on SSHing to servers in the service, see the [Advanced Troubleshooting with the BOSH CLI](https://docs.pivotal.io/pivotalcf/1-10/customizing/trouble-advanced.html).
 
-1. SSH into the `postgresql-master` server using the `bosh` tool:
+1. SSH into the `consul` server using the `bosh` tool:
     <pre class="terminal">
-    bosh ssh postgresql-master
+    bosh ssh consul-server 0  
+    </pre>
+
+1. Identify the current primary by querying Consul:
+    <pre class="terminal">
+    sudo su - vcap
+    curl -sSL http://localhost:8500/v1/catalog/service/postgresql-zone1?tag=primary \
+    | jq -r '.[] | .Node'
+    </pre>
+
+1. SSH into the `postgresql` server (identified above) using the `bosh` tool:
+    <pre class="terminal">
+    bosh ssh postgresql-zone1 <index identified above>
     </pre>
 
 1. Switch to the root user: 
@@ -109,6 +121,7 @@ For guidance on SSHing to servers in the service, see the [Advanced Troubleshoot
 
 1. Stop postgresql services:
     <pre class="terminal">
+    monit unmonitor postgresql
     monit stop postgresql
     </pre>
 
@@ -119,15 +132,12 @@ For guidance on SSHing to servers in the service, see the [Advanced Troubleshoot
 
 1. Verify that backups are available:
     <pre class="terminal">
-    pgbackrest --config=/var/vcap/store/pgbackrest/config/pgbackrest.conf \
-      --stanza=main info
+    pgbackrest --stanza=main info
     </pre>
 
 1. Restore the database:
     <pre class="terminal">
-    pgbackrest --config=/var/vcap/store/pgbackrest/config/pgbackrest.conf \
-      --stanza=main \
-      --delta restore
+    pgbackrest --stanza=main --delta restore
     </pre>
 
 1. Switch to root:
@@ -138,6 +148,7 @@ For guidance on SSHing to servers in the service, see the [Advanced Troubleshoot
 1. Start the database:
     <pre class="terminal">
     monit start postgresql
+    monit monitor postgresql
     </pre>
 
 ##<a id='disaster-recovery'></a> Restore Point in Time
@@ -147,9 +158,21 @@ These instructions demonstrate how the database can be restored using a point in
 The following requires an administrator to SSH to the `postgresql-master` server.
 For guidance on SSHing to servers in the service, see the [Pivotal documentation](https://docs.pivotal.io/pivotalcf/1-8/customizing/trouble-advanced.html).
 
-1. First, SSH into the `postgresql-master` server using the `bosh` tool:
+1. SSH into the `consul` server using the `bosh` tool:
     <pre class="terminal">
-    bosh ssh postgresql-master
+    bosh ssh consul-server 0
+    </pre>
+
+1. Identify the current primary by querying Consul:
+    <pre class="terminal">
+    sudo su - vcap
+    curl -sSL http://localhost:8500/v1/catalog/service/postgresql-zone1?tag=primary \
+    | jq -r '.[] | .Node'
+    </pre>
+
+1. SSH into the `postgresql` server (identified above) using the `bosh` tool:
+    <pre class="terminal">
+    bosh ssh postgresql-zone1 <index identified above>
     </pre>
 
 1. Switch to the root user:


### PR DESCRIPTION
This patch fixes disaster recovery instructions, removes the auto-failover limitation note and changes `leader/follower` to `primary/replica`.