### PR TITLE
Fix typo in disk instructions

### DIFF
--- a/docs-content/installing.html.md.erb
+++ b/docs-content/installing.html.md.erb
@@ -23,7 +23,7 @@ Installation Dashboard to open the configuration panes.
 
   ![Crunchy PostgreSQL tile](images/tile.png)
 
-2. Configure each section as described below.
+1. Configure each section as described below.
 
 ###<a id='az-net'></a> Configure AZ and Network Assignments
 
@@ -73,6 +73,18 @@ use the defaults.
 
 1. Click **Save**.
 
+###<a id='recommended-sizes'></a> Recommended Sizes
+
+The plans made available to developers need to be configured prior to deployment.
+The following table can be used as a baseline when configuring the plans for use:
+
+| Plan   | vCPU | Memory | Disk  |
+|--------|------|--------|-------|
+| Small  | 4    | 32GB   | 64GB  |
+| Medium | 8    | 64GB   | 128GB |
+| Large  | 16   | 128GB  | 256GB |
+| XLarge | 32   | 256GB  | 512GB |
+
 ###<a id='small-plan'></a> Configure Small Plan Properties
 
 1. Click **Small Plan Properties**.
@@ -80,12 +92,12 @@ use the defaults.
     ![Small Plan Properties](small-plan-properties.png)
 
 1. Configure the VM size for databases servers in the small plan.  This is the size 
-that will be used when a developer requests a small database plan.  If unsure, 
-use the defaults.
+that will be used when a developer requests a small database plan.  For recommendations, 
+see the table above.
 
-1. Configure the VM size for databases servers in the small plan.  This is the disk 
-size that will be used when a developer requests a small database plan.  If unsure, 
-use the defaults.
+1. Configure the Disk size for databases servers in the small plan.  This is the disk 
+size that will be used when a developer requests a small database plan.  For recommendations, 
+see the table above.
 
 1. Click **Save**.
 
@@ -95,13 +107,13 @@ use the defaults.
 
     ![Medium Plan Properties](medium-plan-properties.png)
 
-1. Configure the VM size for databases servers in the medium plan.  This is the size 
-used when a developer requests a medium database plan.  If unsure, 
-use the defaults.
+1. Configure the VM size for databases servers in the medium plan.  This is the size
+that will be used when a developer requests a medium database plan.  For recommendations,
+see the table above.
 
-1. Configure the VM size for databases servers in the medium plan.  This is the disk 
-size used when a developer requests a medium database plan.  If unsure, 
-use the defaults.
+1. Configure the Disk size for databases servers in the medium plan.  This is the disk
+size that will be used when a developer requests a medium database plan.  For recommendations,
+see the table above.
 
 1. Click **Save**.
 
@@ -112,12 +124,12 @@ use the defaults.
     ![Large Plan Properties](large-plan-properties.png)
 
 1. Configure the VM size for databases servers in the large plan.  This is the size
-used when a developer requests a large database plan.  If unsure, 
-use the defaults.
+that will be used when a developer requests a large database plan.  For recommendations,
+see the table above.
 
-1. Configure the VM size for databases servers in the large plan.  This is the disk
-size used when a developer requests a large database plan.  If unsure,
-use the defaults.
+1. Configure the Disk size for databases servers in the large plan.  This is the disk
+size that will be used when a developer requests a large database plan.  For recommendations,
+see the table above.
 
 1. Click **Save**.
 
@@ -127,13 +139,13 @@ use the defaults.
 
     ![Extra Large Plan Properties](extra-large-plan-properties.png)
 
-1. Configure the VM size for databases servers in the extra large plan.  This is 
-the size used when a developer requests a large database plan.  If 
-unsure, use the defaults.
+1. Configure the VM size for databases servers in the extra-large plan.  This is the size
+that will be used when a developer requests a extra-large database plan.  For recommendations,
+see the table above.
 
-1. Configure the VM size for databases servers in the extra large plan.  This is 
-the disk size used when a developer requests an extra large database 
-plan.  If unsure, use the defaults.
+1. Configure the Disk size for databases servers in the extra-large plan.  This is the disk
+size that will be used when a developer requests a extra-large database plan.  For recommendations,
+see the table above.
 
 1. Click **Save**.
 


### PR DESCRIPTION
Fixed a typo in the instructions with regards to disk sizing and added a recommended sizing table to make instructions easier to follow.