### PR TITLE
Add 2gb warning note

### DIFF
--- a/docs-content/installing.html.md.erb
+++ b/docs-content/installing.html.md.erb
@@ -85,6 +85,8 @@ The following table can be used as a baseline when configuring the plans for use
 | Large  | 16   | 128&nbsp;GB  | 256&nbsp;GB |
 | XLarge | 32   | 256&nbsp;GB  | 512&nbsp;GB |
 
+**Note**: Do not set any PostgreSQL VMs to be less than 2GB of memory.
+
 ###<a id='small-plan'></a> Configure Small Plan Properties
 
 1. Click **Small Plan Properties**.


### PR DESCRIPTION
Added a warning to avoid VMs less than 2gb of memory due to a bug found when calculating appropriate configuration settings for the VM.