### PR TITLE
Add warning about cores/memory

### DIFF
--- a/docs-content/installing.html.md.erb
+++ b/docs-content/installing.html.md.erb
@@ -85,7 +85,8 @@ The following table can be used as a baseline when configuring the plans for use
 | Large  | 16   | 128&nbsp;GB  | 256&nbsp;GB |
 | XLarge | 32   | 256&nbsp;GB  | 512&nbsp;GB |
 
-<p class="note"><strong>Note</strong>: Do not set any PostgreSQL VMs to less than 2&nbsp;GB of memory.</p>
+<p class="note"><strong>Note</strong>: Do not set any PostgreSQL or pgBackrest VMs to less than 4&nbsp;GB of memory.</p>
+<p class="note"><strong>Note</strong>: Do not set any PostgreSQL or pgBackrest VMs to less than 2 cores.</p>
 
 ###<a id='small-plan'></a> Configure Small Plan Properties
 


### PR DESCRIPTION
Adding a warning to provision at least 4gb of memory and 2 cores on the Postgres and Backup servers.  