### PR TITLE
Add service role info

### DIFF
--- a/docs-content/_service_credentials.erb
+++ b/docs-content/_service_credentials.erb
@@ -12,17 +12,82 @@ The following keys are available in the service credentials JSON object:
 * **read_port**: TCP port for database read commands
 * **read_uri**: standard postgresql connection URI for database read commands;
 `postgresql://username:password@db_host:db_port/db_name`
+* **service_role**: the database role that is granted privileges to the service
+instance database; this role can not be used to connect to the database directly
 * **uri**: standard postgresql connection URI for database write commands;
 `postgresql://username:password@read_host:read_port/read_name`
-* **username**: database user
+* **username**: the database role used to connect to the service instance
+database; this role inherits privileges from **service_role** and is unique for
+each binding
 
-The following keys are available if `monitoring` parameter was set to `true` during
-provisioning:
+The following keys are available if `monitoring` parameter was set to `true`
+during provisioning:
 
 - **prometheus_host**: host of the Prometheus server for monitoring data
 - **prometheus_port**: connection port for the Prometheus server
 - **prometheus_username**: username for accessing Prometheus
 - **prometheus_password**: password for accessing Prometheus
+
+#### Database Roles
+
+##### Service Role
+
+The service role is created at the same time as the service instance. The name
+of the database role matches the value of the **db_username** parameter given
+to `cf create-service`. This role is granted ownership of the service instance
+database and the `public` schema. The service role is identified by the
+**service_role** key of the binding credentials object.
+
+<p class="note"><strong>Note</strong>: The service role has the
+<code>NOLOGIN</code> attribute, therefore it can not be used directly to connect
+to the service instance database. The binding role should be used to connect to
+the database.
+</p>
+
+##### Binding Role
+
+A binding role is created for each service binding. This ensures each binding
+or service key is a unique set of credentials. It is granted the service
+role and inherits the service role's privileges. The binding role is identified
+by the **username** key of the binding credentials object.
+
+##### Database Object Ownership
+
+A database object is owned by the role that creates it. Database objects may
+only be altered or dropped by the owner or a role granted the owner's role.
+
+The binding role will own any database objects it creates. Privileges for these
+objects are granted to the service role. This allows subsequent binding roles to
+access an object with the same privileges as the binding role that created
+the object.
+
+When a binding is destroyed, object ownership is transferred from the binding
+role to the service role. This allows subsequent binding roles to alter or drop
+database objects created by previous binding roles.
+
+Services with multiple active bindings that create database objects may have
+objects owned by multiple roles. In this scenario, an attempt to alter or drop
+an object that is not owned by the current binding role or the service role
+may fail with an error similar to:
+
+```
+ERROR:  must be owner of ...
+```
+
+Therefore, it is recommended to create database objects as the service role
+instead of the binding role. This can be accomplished by using the `SET ROLE`
+command. For example:
+
+```
+SET ROLE <service_role>; CREATE TABLE t (id SERIAL, text TEXT);
+```
+
+If this is not possible, `SET ROLE` may be used when an object needs to be
+altered or dropped:
+
+```
+SET ROLE <service_role>; ALTER TABLE t ADD COLUMN moretext TEXT;
+```
 
 #### Accessing the Primary Database Server
 


### PR DESCRIPTION
## Overview
These changes add information about the service role, including how and when it should be used.

## Testing Method
Build and deploy app locally to verify formatting:
```
cd docs-book
bundle install
bundle exec bookbinder bind local
cat >/tmp/manifest.yml <<EOF
---
applications:
- name: docs-crunchy-data
  memory: 256M
  disk_quota: 512M
  buildpack: ruby_buildpack
  command: bundle install && bundle exec rackup --port "$PORT"
EOF
cf push -f /tmp/manifest.yml
firefox http://docs-crunchy-data.local.pcfdev.io/crunchy/using.html#service-credentials
```